### PR TITLE
Fix issue where wellbore heads where shown black for exploration when…

### DIFF
--- a/src/WellboreModule.ts
+++ b/src/WellboreModule.ts
@@ -126,10 +126,13 @@ export default class WellboreModule extends ModuleInterface {
       wellboreWidth: wellboreResize.max.scale,
       tick,
     });
-    if (wellbore.mesh) this.containers.wellbores.addChild(wellbore.mesh);
+    if (wellbore.mesh) {
+      this.containers.wellbores.addChild(wellbore.mesh);
+    }
     this.containers.labels.addChild(wellbore.label.text);
     this.containers.labels.addChild(wellbore.label.background);
     group.append(wellbore);
+    root.recalculate(true);
 
     // Add to line dictionary
     if(!wellbore.interpolator.singlePoint) this.lineDict.add(projectedPath, wellbore);
@@ -143,7 +146,7 @@ export default class WellboreModule extends ModuleInterface {
     }
   }
 
-  set(wells: SourceData[], key: string = 'default') : Promise<void> {
+  set(wells: SourceData[], key: string = 'default', batchSize: number = null) : Promise<void> {
     return new Promise((resolve, reject) => {
       const group = this.groups[key];
       if (!group) {
@@ -155,14 +158,14 @@ export default class WellboreModule extends ModuleInterface {
 
         this.asyncLoop.Start(key, {
           iterations: wells.length,
-          batchSize: 20,
+          batchSize: batchSize || this.config.batchSize || 20,
           func: i => this.addWellbore(wells[i], group),
           postFunc: () => this.pixiOverlay.redraw(),
           endFunc: () => {
             this.pixiOverlay.redraw();
             resolve();
           }
-        });
+        }, 0);
       } catch (err) {
         reject(err);
       }

--- a/src/utils/wellbores/Config.ts
+++ b/src/utils/wellbores/Config.ts
@@ -12,7 +12,7 @@ export interface TickConfig {
 export interface Config {
   /** Relative scale of all components (Default: 1.0). */
   scale: number;
-  /** Amount of wellbores per batch. (Default: 25) */
+  /** Amount of wellbores per batch. (Default: 20) */
   batchSize: number;
   /** Origin zoom level, i.e. where input for scaling function is 0. (Default: 0) */
   zoomOrigin: number;
@@ -86,7 +86,7 @@ export function getDefaultConfig(input?: InputConfig): [ Config, ExtraConfig ] {
 
   const outputConfig: Config = {
     scale: 1.0,
-    batchSize: 15,
+    batchSize: 20,
     zoomOrigin: 0,
     gridSize: 2,
     wellboreResize: {


### PR DESCRIPTION
… exploration was disabled while data was being loaded/processed

Allow configuring batch size from outside of component for tuning
Use setTimeout() instead of interval in case processing take more time than interval, ref: https://developer.mozilla.org/en-US/docs/Web/API/setInterval#usage_notes