### PR TITLE
Bumped pixi.js version from 7.1.2 to 7.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@equinor/videx-vector2": "^1.0.44",
         "d3-color": "^3.1.0",
         "earcut": "^2.2.2",
-        "pixi.js": "^7.1.2",
+        "pixi.js": "^7.2.2",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -3044,45 +3044,71 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.1.2.tgz",
-      "integrity": "sha512-o5f9IwzqH7iCX05ougmh2r4In9QUVpV+D9UjyCEN8ZKBXfjEk56/VwBd1xX1iYABSktwozX2i3JyozURWD/GOA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.2.2.tgz",
+      "integrity": "sha512-FXFToqJSh7P8zshnVCp/wHzZZnCYJAZoDHyVjnZsHc9+3vfZCfUczQ5CyxmOg7DTRg5Wn9HahImxvAdwY3wodA==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/events": "7.2.2"
+      }
     },
     "node_modules/@pixi/app": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.1.2.tgz",
-      "integrity": "sha512-0fMeIfySiQtp75a+UmqtF50VwgeIfjoaDqpdmNtVdIThhcLVXW1BZSdAlQUHWsNWQXsRs2isXYPIrz9B71XrWA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.2.2.tgz",
+      "integrity": "sha512-S07adWs3/AshqQVhkrERHBfwTOXP0UN1WwEN2O/czigctCcv8zB8xAmv5fND2pS29XZZ6jhj+i4mbnDmpb/KJw==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2"
+      }
     },
     "node_modules/@pixi/assets": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.1.2.tgz",
-      "integrity": "sha512-Vq9Qxr833HWZGRJ3MJAJQSQLUG7fTVBnrTIv6IKlflAn9k7x63EqOCpyFXVce7pmRcuAgNMfgvboxip+9EBhGw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.2.2.tgz",
+      "integrity": "sha512-YtudMqxyPx1yZ3oczP1OIMQJlb0/psymZGU7PMyea0wSYol14imMOdNa0sNFz/at6a6kM1w/vQdlz+8AqML1vw==",
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.7"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/utils": "7.2.2"
+      }
+    },
+    "node_modules/@pixi/color": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.2.2.tgz",
+      "integrity": "sha512-rg3zrwnkCtfX73sbIDuXyBlQWdRlREs4UlvC6gJ0EGHbGtwAK0Zz041fDW8isYYLcjd3LopVlNrjrFGE+v+adQ==",
+      "dependencies": {
+        "colord": "^2.9.3"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.1.2.tgz",
-      "integrity": "sha512-DX9eHNSCn5b4y//FCBU/6MglbxcEN/sHXCH0Lsm5oteetXDaQ+vREhkPDiy6ApsvdImzP+qYgVDkE1gplLlYIQ=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.2.2.tgz",
+      "integrity": "sha512-+cnNUBFAduQ71eTKiETLUn3mXqtGA58D0+dFqw53XyvSoceGf+xvyXQhzkGAKwbANvQXEsRaStZ1euW+tGGDag==",
+      "peerDependencies": {
+        "@pixi/assets": "7.2.2",
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/constants": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.1.2.tgz",
-      "integrity": "sha512-fJflBZJm7fkLmHE5jwl2sc4oekburtM881MmAexYnZVfLNj76mNquElwOd4xAf5iQY43J0g05tSObXtin8a4Fg=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.2.2.tgz",
+      "integrity": "sha512-hHdXfhRNOCEg/5LbR4izY9feEyxtjNKs6l4Np87iiglvK5oj2hjiLz3c1VHWooNy8VQmndcLC11Tl0krxuQjiw=="
     },
     "node_modules/@pixi/core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.1.2.tgz",
-      "integrity": "sha512-yhKYxiDFsS0KdB2ARXyfvQ6+J0IFXzpKSFNOl+MAPfla3cR4QxInln8CoIEB9CJkB+GoHq2tU5+O4xx15ESIvw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.2.2.tgz",
+      "integrity": "sha512-grDYsthKpb9OPlAPrzutogodciky6x8eWz+0ER+I5KBzK/1w1fBYnYiQZCH0MByNJMABE75cynWv9inMJu0rEQ==",
       "dependencies": {
-        "@pixi/constants": "7.1.2",
-        "@pixi/extensions": "7.1.2",
-        "@pixi/math": "7.1.2",
-        "@pixi/runner": "7.1.2",
-        "@pixi/settings": "7.1.2",
-        "@pixi/ticker": "7.1.2",
-        "@pixi/utils": "7.1.2",
+        "@pixi/color": "7.2.2",
+        "@pixi/constants": "7.2.2",
+        "@pixi/extensions": "7.2.2",
+        "@pixi/math": "7.2.2",
+        "@pixi/runner": "7.2.2",
+        "@pixi/settings": "7.2.2",
+        "@pixi/ticker": "7.2.2",
+        "@pixi/utils": "7.2.2",
         "@types/offscreencanvas": "^2019.6.4"
       },
       "funding": {
@@ -3091,161 +3117,267 @@
       }
     },
     "node_modules/@pixi/display": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.1.2.tgz",
-      "integrity": "sha512-+XTsk42xuBuhzXjMMIDU7+Oou2qbiEy3NK2yuZTbXXMqWzcrGvlPr/9Dx5DU4ObPsYOO8MBB/Vag8bFB38yPlw=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.2.2.tgz",
+      "integrity": "sha512-zUkFhwnqsKatwB1I3ZAD1on1RCvuTLZ1MV1JQd97pMBAJBC9UvDuKIJ6Zcr377YXKFnIFGFFxat9LyVTUxTWvQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/events": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.1.2.tgz",
-      "integrity": "sha512-KVGrvXayAgFxnq7o/QslbA/2f7uVvhWb1W7l49BWIyGgbUpV0NLQmk8qS5LFuWMgTalm4CWBchnjQ0ZExy12Mw=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.2.2.tgz",
+      "integrity": "sha512-9JuBgB0uI9Zjm7GNAAJ3jmOXAbgHBCUXfOAzZqn68/z9W168Lb56akpXRPI5/Y6Ef4kxIWjZlqE31vrLEn33rA==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/utils": "7.2.2"
+      }
     },
     "node_modules/@pixi/extensions": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.1.2.tgz",
-      "integrity": "sha512-IfUDoGiCDmBf4wiFO1YQYtIrE2DmV4XsPxQe6XE82KTxttTHdHO8XlVE6HiE+Ldtc08kLvY3iQ/y1dnpLBT1gA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.2.2.tgz",
+      "integrity": "sha512-b54qLl/GQK6VKgTiaeCg8tyujykfBhLn6PGGoY0fyWXEOYXRPyZ/oZDadz0bhLURwPzfnHbblINkK8L6JJpCSQ=="
     },
     "node_modules/@pixi/extract": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.1.2.tgz",
-      "integrity": "sha512-/31k0YP8vTQAhYcBk6etQbh0jeXTQASL/X078xELfH3/6fCm7xAwEgglJCWHDecK7mLMRRNrahmHBK164zO9Cw=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.2.2.tgz",
+      "integrity": "sha512-zAqQY8DvbdBB/hVJmHL3pn5xS5OUwsl0+Jj7+K4MtqVtI/ssogF2wWml9+KIkXVfe30IY7pWaca+vHBOapN2mg==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.1.2.tgz",
-      "integrity": "sha512-o8bnFYU3kxrMJQ5hjRmmP+ygpSeoOH7KCXZwq/4vQNzUETrTaeyZvcIt4FIVVGyKQ4h1Gh3qipZ0EouQbLI5xA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.2.2.tgz",
+      "integrity": "sha512-Fx4PhhyXQ30wVE3kVRDzSgqrG25Eh2wLSwdikvZTVUPvjYNHZnSH9cd2M1L414C/tVUnQ0paWamw/nodudH0yQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.1.2.tgz",
-      "integrity": "sha512-WtYkpEBY5J7TObxmioigEWJCs9EXQKUnXEWztGZCtTghG4xA1XAIAEzLP5fEXCifiaU6a9Ro7Z/V1vPFalxlJg=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.2.2.tgz",
+      "integrity": "sha512-yE1IGbzijwWtxqPfuouApgrvPEJr3bcCAZyi66DJeTBI/Uphdgyv/E+M8nB5tWnT3jkAAY5MredQA6noh/wtxA==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.1.2.tgz",
-      "integrity": "sha512-o9+Sb6r7WmJ7bJkxQsdbehTjWZtSlgCfLaIOglDlN39nsNIR2rHguiRimKfEKmKA5e6QsNiTi4qNMgRYEuPiYg=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.2.2.tgz",
+      "integrity": "sha512-g7d8QaUtAiQ4cL5CQM7sql1hMAYu+p4NfzTKrHyHHKV9bA6SKtDaaUkR8aCgYIMqMXZUQ2ARHHm2TD6FF1yCUg==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.1.2.tgz",
-      "integrity": "sha512-PdWUtdC9MYD+ZhPBAqIwFKn2XSFoDbIL8gFz/oiECoTtWn7sujRQuvqVjbp6Nvu4QKvhlBDq/WDTe3Js+EPVbA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.2.2.tgz",
+      "integrity": "sha512-Bf8SMZQMw3gLVL3uRBhlYQMGWVMfzE+bGN+ICGZEkt+EBJuu2P+6PYclWKAO6vVzv61Z/8R5aEZDcyO2KqCneQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.1.2.tgz",
-      "integrity": "sha512-vW47OpemETweJW6OaAy+jI/RUWtOdEhrXH7bPTDIJyTEij62xgec95f9AWU/OfWzK5lOsoWXtlV//mvGUdi86Q=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.2.2.tgz",
+      "integrity": "sha512-X+XflHyAUAYlud7tK8jrQ+XhBv+N9TepTrBeIKALF+134zIS8fMTQVWBtj7as/Iva+RNEq3yn8jq7uhAO54eBw==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.1.2.tgz",
-      "integrity": "sha512-SXVP0Og6ByTfmkd2Xnesi+m9jBLvi3x2aqjXDWgM9wNiXTF67CtfHzIwgs5A+wGADSylEIyZz4KMiUaJ2AH3Zw=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.2.2.tgz",
+      "integrity": "sha512-TpnTRoiYK644EBZgyu23xE13k7v53rkjpd6NkaMV2cmVmNUCRS/Mqvn+tInfKCwI69S4q2/sp/X+car8dhlyGQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/graphics": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.1.2.tgz",
-      "integrity": "sha512-R32KfpIfBABDvVzX9Rh59oyP2p7TXKcakEi/eOBF+paGmDpIYXK2Ola4VfoalqZIXFMhsFST36iiJv/cRaKRdQ=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.2.2.tgz",
+      "integrity": "sha512-fgF1nGlIjFE1aAJ1UvGi+k6P1Hbb5J71kg0sV1TnvqJKHxJCNdrl7muyb+aowWtyvGDQ93TkdpLucdl9Qutepw==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/sprite": "7.2.2"
+      }
     },
     "node_modules/@pixi/math": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.1.2.tgz",
-      "integrity": "sha512-mLfbdo/Al78YLTstTfnqzxuZy/L0ef9oaL4Wc58Jm+9VjqXkCbI2zIioERdb/KPYWFIABMC0ZIjE5vTCYdyphw=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.2.2.tgz",
+      "integrity": "sha512-h4Qb2BOhiGoWQnG7RdS0nK5P9k33950S158GqLAXf+jN19fENPJibfh05ckdUwkVtYnd+PuBqcriH/vrRPICfQ=="
     },
     "node_modules/@pixi/mesh": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.1.2.tgz",
-      "integrity": "sha512-1N45fW/Y5p+ixEAfihe1ZpTIdx7KY3Wce0coGv42k4pCeKykGMR9ibCL5ThJoHLS1mtU3QIfmmj5HC8ZW8SwjA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.2.2.tgz",
+      "integrity": "sha512-utJQsPGmV11Kl310/lyemEAHYpi3oSv+g2mxtRcTgpRyCYj6r7677ECcbp6CJO3XBr4AGqyqFx5IUmIr5AD2tQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2"
+      }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.1.2.tgz",
-      "integrity": "sha512-ffV8Ajo3LAJdn+eUkixEK48tTsnJjyV9+YrbSK1Lciezx2jvQabmeBDmowBGFZnKjrgJFEJWeBDCKlyhcffkOg=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.2.2.tgz",
+      "integrity": "sha512-xE5+mVXQeIut74uKrvl1zHoT7gpEy85CCbljOhrr5FaDclxhF8qFy0m3WGJcxAzAIiCg7kkGlN3GWDgXR3Vgag==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/mesh": "7.2.2"
+      }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.1.2.tgz",
-      "integrity": "sha512-bGOKkuQj3IHrJHY1a2oSKM8U0nvnNxcr2+IRchx9ncaE3V9VUxHyNgj/bn5ed9V0momRzXCtxkT+rA8V8RDw4g=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.2.2.tgz",
+      "integrity": "sha512-sI1w/CppIiTcdtm0JGqe4pc5L7XSCl6MIGJnLqgixLAWav12jMRw44Yvwy6RJedEwQ6IdTGv19MJAlUKMkEsTw==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/sprite": "7.2.2"
+      }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.1.2.tgz",
-      "integrity": "sha512-yFzJCegHc5JZ/kGBi/UeXvtDdF7Wfzg9uIAbK+zc/YL0PjB3+Q7AKcR7Exq4XMKwUBAd24S5aTDR23WfW5Z7OA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.2.2.tgz",
+      "integrity": "sha512-rlfpaG7DSYo52rVFwparIv+rTFshCdwQgY67+I/ppLHyJCVcmCd5rhAygRs9JrNw8mFniWrGZlJSiOqq92ezFg==",
+      "peerDependencies": {
+        "@pixi/display": "7.2.2"
+      }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.1.2.tgz",
-      "integrity": "sha512-nX/zAwRfK9Uja7Jlj3wrb8am4CIWY7Z6ZRvRqR9VM2yS2eE6KLD4X706gHxlKQnVav/Wup1n6AFJdk68d25Tbg=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.2.2.tgz",
+      "integrity": "sha512-6Zj3yr84kOQN+XaXuNXWcI84yCw3A6XI1PPtIHGDZpa5Zsa4nvFBh5MA3R6Gg4eCnB+M6D3p49huiUC8zdXkIw==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2"
+      }
     },
     "node_modules/@pixi/particle-container": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.1.2.tgz",
-      "integrity": "sha512-BaNT226SIs04qBwiUHanTYsWZjCFivW9jCZrV9+2N5BrNaCw4SWOfoHwy23AxaWZC2coU2AkM9MGoOeD75Qq9A=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.2.2.tgz",
+      "integrity": "sha512-S5yfbXLOZjF8sCTzlkezSpf2gDjDTMJH2GwUxZK/Uq0NsuQu3/FL74m4GYYhJ9rxw3BCCb0weBncqEUtS8I70A==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/sprite": "7.2.2"
+      }
     },
     "node_modules/@pixi/prepare": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.1.2.tgz",
-      "integrity": "sha512-LwJsseLklfeHRTMAwtwew3ficceSRuxv7H9VMAvk588+UXEQGOINVG3sE9CF7nwoqU8Ry55BlR9IGCQGP8bCzA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.2.2.tgz",
+      "integrity": "sha512-QpFyZOjbaf4J73AlLgeYmn8OnK94xH5oGXDus/ihCc7ntYhv3oeAIOT81zGIkWms6G8ChsanPrHniw8S5YU69Q==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/graphics": "7.2.2",
+        "@pixi/text": "7.2.2"
+      }
     },
     "node_modules/@pixi/runner": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.1.2.tgz",
-      "integrity": "sha512-mtkNlABmQGD208nYsnUjZlMzsJ2+pug7wmLBcDJC8jtD3PFbPorI+CsqdT1ivPYKXSMZq5/rcoWTk1G9PUeRog=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.2.2.tgz",
+      "integrity": "sha512-rXbMGtk1aS8OSR/yMzdHxdWQIaEKAIV6k37L8Zt/wAD1lmTDqvDTjm8BSxPLQMkNGNFL+3YoBgTev1e7aNgWxw=="
     },
     "node_modules/@pixi/settings": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.1.2.tgz",
-      "integrity": "sha512-5dg4+WvqA1OLVvDjw49664Mc6x26O0WPzpCHTxt9WrzKqE6g6S2A+Sxn8E6Eq+/86excpYf0JCR8F2d+ObpL1Q==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.2.2.tgz",
+      "integrity": "sha512-IqkiEZ3c/XAU1iPCuUy+MkzfzI3Hw7xHL24C+QrwbaJtJTodoKyfuKsk/H7T7Sz2f0gop1lfqwC3jGRiYzS/2g==",
       "dependencies": {
-        "@pixi/constants": "7.1.2",
-        "@types/css-font-loading-module": "^0.0.7"
+        "@pixi/constants": "7.2.2",
+        "@types/css-font-loading-module": "^0.0.7",
+        "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.1.2.tgz",
-      "integrity": "sha512-pUdU+QdWKuYvrx7iaM7Pr9otEGPUVCfhUFO+z13uJeDPg3kx8HX5AwzAz0dl1B7FOfO0ugYlpzWZAF9vYNGd+Q=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.2.2.tgz",
+      "integrity": "sha512-GFt7Vyy41rVqQJOtstTD5mC+Dgyc6duySWrsRvCTSD6Q7nvJC+y7Zpgl6If9wbq2wx8CRGk9KlLeBI16rra69Q==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2"
+      }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.1.2.tgz",
-      "integrity": "sha512-zN4UN6xUMjmrjSoFe9qh+gxMI+UJEa1p+wtKjKMrrUzVFsdRo7KuCRq5tzhDd32t+phWkIv1f3E/LAbQ7ZdNsA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.2.2.tgz",
+      "integrity": "sha512-nx2Lg8sLnAoMkZZaZlGui/rH3kOOpeHqG3NJmvvLv2q1sFGpz4rR7MNh31CnZlz5GjH/6ZGrZXKDx3Vk9Nw1TA==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/sprite": "7.2.2"
+      }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.1.2.tgz",
-      "integrity": "sha512-CbBltFd5UnwFhMqAKXu/PnBP0oXYgT0Io3OnMKGG9Ux6DC2a+qrqOZaJK9EgrD8QxN7f+LjMs+H/eePrNQhXGg=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.2.2.tgz",
+      "integrity": "sha512-Qz73BUDo4qO0SRgIO11jgdi45EAqKw/abKwEuP4ONLTPSOj75tQhvFd4U2Od4O+U+1JI1Ao0gQJDiBC8JuCrdg==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/sprite": "7.2.2"
+      }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.1.2.tgz",
-      "integrity": "sha512-HgUAd8yCVFbIxdZ0JfRI8RdF2W4KGOnfrcPvqNGCp+DRl2PvaGarnf6phpgW3xR11IEzGWHvlQyYDGWM+v1cuA=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.2.2.tgz",
+      "integrity": "sha512-XMFDa78TRM1JgTa9b4wtSObibNzUFyZdOUtD/djVnSJpqlHK2X3CMdYsT3ccP1SyhDB7im6kKnAmjljxgd4jRQ==",
+      "peerDependencies": {
+        "@pixi/assets": "7.2.2",
+        "@pixi/core": "7.2.2"
+      }
     },
     "node_modules/@pixi/text": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.1.2.tgz",
-      "integrity": "sha512-/boBiFCjlliZaWHg9GC4sVB0OLE1Yfbkh8Mg1BPwZJzf/dPxOb1jiWqlfUoTAD6G+widShTWt87mgSGHirTZow=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.2.2.tgz",
+      "integrity": "sha512-hj6oOZkoWQx+p6fQcsiN2kXRyqsjNsjyNgte8xqoUfkmu2kUkL8HpyrKN/npGaIDlLRH1LTfAO1xuKyiLSmtUg==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/sprite": "7.2.2"
+      }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.1.2.tgz",
-      "integrity": "sha512-6poTJXkJMDme4uixixSROsvBVRDFf67IJxVjFNlahJyvPFtChvlNBm97w86CWY1YkiZjFPYLEZTkCCp/1/Q52A=="
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.2.2.tgz",
+      "integrity": "sha512-7tbrh49wgU1EKODSo/TjeaD5RDmvcLQbEehfUF+2dligd8dlsE+DRjgGebbzzmk73ViEdthcN2VSSeF2W8+blw==",
+      "peerDependencies": {
+        "@pixi/assets": "7.2.2",
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/mesh": "7.2.2",
+        "@pixi/text": "7.2.2"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.2.2.tgz",
+      "integrity": "sha512-HQqXK1j2rA9zXZrLgGerTIAOXWS95vV0oPeC8rMQESPC560wC9qtG165OLBo5BbtBukEJlT+n6QYNORqaYY5lQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/sprite": "7.2.2",
+        "@pixi/text": "7.2.2"
+      }
     },
     "node_modules/@pixi/ticker": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.1.2.tgz",
-      "integrity": "sha512-zSdW3oIgfKaIwRWx3xKlS9SpJpa8efQNu70JXVbEA5fX0tZC2BIAP4GUFOM/PuyqyB95cCxGJO7KaL3xFPz/tQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.2.2.tgz",
+      "integrity": "sha512-fNW1WWnDfyc7pk+AUokUeurK19gG3bIX/NQGB+Y7KiP84EwKZbLwMXQWIhc3aRZt7lzEA8yFXQ0+Oqi5IIGFUQ==",
       "dependencies": {
-        "@pixi/extensions": "7.1.2",
-        "@pixi/settings": "7.1.2",
-        "@pixi/utils": "7.1.2"
+        "@pixi/extensions": "7.2.2",
+        "@pixi/settings": "7.2.2",
+        "@pixi/utils": "7.2.2"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.1.2.tgz",
-      "integrity": "sha512-UsEQn8Oz9RFJMmi8GzPJWHH6h2+Ftcfvt3JgirqvyFH7i5it7uAScA0CRCtQkc72Ot25lGfRDSbwI+f3RqdLMw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.2.2.tgz",
+      "integrity": "sha512-+EMCAA+lDe8AmLzrwAhCNybevuOcGyFHSo1NtRpd7Z1ocrG0atzq4gjKxUX8VoqJ89rWFZdhZpdGPMh0xRELaQ==",
       "dependencies": {
-        "@pixi/constants": "7.1.2",
-        "@pixi/settings": "7.1.2",
+        "@pixi/color": "7.2.2",
+        "@pixi/constants": "7.2.2",
+        "@pixi/settings": "7.2.2",
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.4",
         "eventemitter3": "^4.0.0",
@@ -10294,6 +10426,11 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
+    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -15408,6 +15545,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
+    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -19856,39 +19998,40 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.1.2.tgz",
-      "integrity": "sha512-bPEn8e/fwm/8u+Y1CTUsGtFqZXhX+s4ZL+unuPVoaSmad/YTdP/YJekxr1SdDY+Ho5JiFFagh7XgZxB08N/xvw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.2.2.tgz",
+      "integrity": "sha512-fY/DvZyK5DbgP1CU0VpauZ3c3ls7YcqXMTe2x6b787dm7WOuXeIF3L5yIBtf/38+ZmcqTqCN/PWYA9v6HZ/SQg==",
       "dependencies": {
-        "@pixi/accessibility": "7.1.2",
-        "@pixi/app": "7.1.2",
-        "@pixi/assets": "7.1.2",
-        "@pixi/compressed-textures": "7.1.2",
-        "@pixi/core": "7.1.2",
-        "@pixi/display": "7.1.2",
-        "@pixi/events": "7.1.2",
-        "@pixi/extensions": "7.1.2",
-        "@pixi/extract": "7.1.2",
-        "@pixi/filter-alpha": "7.1.2",
-        "@pixi/filter-blur": "7.1.2",
-        "@pixi/filter-color-matrix": "7.1.2",
-        "@pixi/filter-displacement": "7.1.2",
-        "@pixi/filter-fxaa": "7.1.2",
-        "@pixi/filter-noise": "7.1.2",
-        "@pixi/graphics": "7.1.2",
-        "@pixi/mesh": "7.1.2",
-        "@pixi/mesh-extras": "7.1.2",
-        "@pixi/mixin-cache-as-bitmap": "7.1.2",
-        "@pixi/mixin-get-child-by-name": "7.1.2",
-        "@pixi/mixin-get-global-position": "7.1.2",
-        "@pixi/particle-container": "7.1.2",
-        "@pixi/prepare": "7.1.2",
-        "@pixi/sprite": "7.1.2",
-        "@pixi/sprite-animated": "7.1.2",
-        "@pixi/sprite-tiling": "7.1.2",
-        "@pixi/spritesheet": "7.1.2",
-        "@pixi/text": "7.1.2",
-        "@pixi/text-bitmap": "7.1.2"
+        "@pixi/accessibility": "7.2.2",
+        "@pixi/app": "7.2.2",
+        "@pixi/assets": "7.2.2",
+        "@pixi/compressed-textures": "7.2.2",
+        "@pixi/core": "7.2.2",
+        "@pixi/display": "7.2.2",
+        "@pixi/events": "7.2.2",
+        "@pixi/extensions": "7.2.2",
+        "@pixi/extract": "7.2.2",
+        "@pixi/filter-alpha": "7.2.2",
+        "@pixi/filter-blur": "7.2.2",
+        "@pixi/filter-color-matrix": "7.2.2",
+        "@pixi/filter-displacement": "7.2.2",
+        "@pixi/filter-fxaa": "7.2.2",
+        "@pixi/filter-noise": "7.2.2",
+        "@pixi/graphics": "7.2.2",
+        "@pixi/mesh": "7.2.2",
+        "@pixi/mesh-extras": "7.2.2",
+        "@pixi/mixin-cache-as-bitmap": "7.2.2",
+        "@pixi/mixin-get-child-by-name": "7.2.2",
+        "@pixi/mixin-get-global-position": "7.2.2",
+        "@pixi/particle-container": "7.2.2",
+        "@pixi/prepare": "7.2.2",
+        "@pixi/sprite": "7.2.2",
+        "@pixi/sprite-animated": "7.2.2",
+        "@pixi/sprite-tiling": "7.2.2",
+        "@pixi/spritesheet": "7.2.2",
+        "@pixi/text": "7.2.2",
+        "@pixi/text-bitmap": "7.2.2",
+        "@pixi/text-html": "7.2.2"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@equinor/videx-vector2": "^1.0.44",
     "d3-color": "^3.1.0",
     "earcut": "^2.2.2",
-    "pixi.js": "^7.1.2",
+    "pixi.js": "^7.2.2",
     "uuid": "^8.3.2"
   }
 }

--- a/src/GeoJSONModule/point.ts
+++ b/src/GeoJSONModule/point.ts
@@ -49,8 +49,8 @@ export default class GeoJSONPoint {
         point = new PIXI.Graphics();
         this.container.addChild(point);
       }
-      const fillColor = properties.style.fillColor ? PIXI.utils.string2hex(color(properties.style.fillColor).hex()) : 0x0;
-      const lineColor = properties.style.lineColor ? PIXI.utils.string2hex(color(properties.style.lineColor).hex()) : 0x0;
+      const fillColor = properties.style.fillColor ? new PIXI.Color(color(properties.style.fillColor).formatHex()).toNumber() : 0x0;
+      const lineColor = properties.style.lineColor ? new PIXI.Color(color(properties.style.lineColor).formatHex()).toNumber()  : 0x0;
       const opacity = properties.style.fillOpacity || 0;
       const offset = 4;
       point.lineStyle(properties.style.lineWidth, lineColor);

--- a/src/WellboreModule.ts
+++ b/src/WellboreModule.ts
@@ -151,6 +151,7 @@ export default class WellboreModule extends ModuleInterface {
     // Append wellbore to root
     root?.append(wellbore);
 
+    // eslint-disable-next-line max-len
     if (this._deferredSelector && (this._deferredSelectorKeys === null || this._deferredSelectorKeys.includes(group.key)) && this._deferredSelector(wellbore.data)) {
       this._deferredSelector = undefined;
       wellbore.setSelected(true);


### PR DESCRIPTION
Fixes an error that occurs _when running videx-map locally_ due to some pixi.js v7.2.2 logic depending on features introduced in pixi.js v7.2.0. Without this fix, any update to the map creates an error message.

- Updated some deprecated code.
- Ignored a long line.