### PR TITLE
ci: upgrade gh actions and node version

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,10 +7,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.0
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.0
+          node-version: 20.x
       - name: npm install, build, and test
         run: |
           npm ci

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -3,23 +3,18 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
-      run: |
-        npm ci
-        npm run build --if-present
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.0
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.0
+      - name: npm install, build, and test
+        run: |
+          npm ci
+          npm run build --if-present
+          npm test
+        env:
+          CI: true


### PR DESCRIPTION
- Upgrade `actions/checkout` to v4
- Upgrade `actions/setup-node` to v4
- Change Node version to `20.x`
- Remove `strategy: matrix` due to no obvious reason for it to be used