### PR TITLE
Remove specific scan of Dependabot on github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-      time: "03:00"


### PR DESCRIPTION
While testing GHAS tool, everything should be scanned (not only github-actions).

Revert https://github.com/equinor/videx-map/pull/136